### PR TITLE
feat: add chess position renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,54 @@ Look at `data.json` file to see urls for each type of boards or sets
     <img src="https://github.com/GiorgioMegrelli/chess.com-boards-and-pieces/blob/master/pieces/3d_wood/bn.png" width="10%" />
     <img src="https://github.com/GiorgioMegrelli/chess.com-boards-and-pieces/blob/master/pieces/3d_wood/br.png" width="10%" />
 </p>
+
+
+## Chess Position Renderer
+
+The `render_position.py` script generates chess position images by combining board and piece PNGs based on a FEN string. It supports:
+
+- Custom board styles and piece sets from the repository
+- FEN notation input (including loading positions from `fen.json` by ID)
+- Configurable square sizes
+- Rendering from either player's perspective (white or black)
+- Custom output filenames
+
+### Installation
+
+Install the required dependencies:
+
+```bash
+uv venv
+source .venv/bin/activate
+uv pip install -r requirements.txt
+```
+
+### Usage
+
+```
+usage: render_position.py [-h] [--fen FEN | --id ID] --board BOARD
+                          --pieces PIECES [--size SIZE] [--side {white,black}]
+                          [--output OUTPUT]
+
+Render chess positions from FEN notation using chess.com board and piece images.
+
+options:
+  -h, --help            show this help message and exit
+  --fen FEN             FEN string representing the chess position (default:
+                        starting position if neither --fen nor --id provided)
+  --id ID               Load FEN from fen.json by position ID
+  --board BOARD         Board style name without .png extension (e.g.,
+                        "brown", "marble")
+  --pieces PIECES       Pieces directory name (e.g., "alpha", "3d_wood")
+  --size SIZE           Size of each square in pixels (default: 80)
+  --side {white,black}  Perspective to render from: white (bottom) or black
+                        (top). Default: white
+  --output OUTPUT       Output filename (default: chess_position.png)
+
+Examples:
+  # Starting position with brown board and alpha pieces
+  render_position.py --board brown --pieces alpha --size 80
+
+  # Custom position
+  render_position.py --fen "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4" --board marble --pieces 3d_wood --size 100
+```

--- a/fen.json
+++ b/fen.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": 1,
+    "fen": "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+  },
+  {
+    "id": 2,
+    "fen": "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
+  },
+  {
+    "id": 3,
+    "fen": "rnbqkbnr/pp1ppppp/8/2p5/4P3/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 2"
+  },
+  {
+    "id": 4,
+    "fen": "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2"
+  },
+  {
+    "id": 5,
+    "fen": "4K3/2k1P3/8/8/8/8/5r2/6R1 w - - 0 1"
+  },
+  {
+    "id": 6,
+    "fen": "8/8/8/4p1K1/2k1P3/8/8/8 b - - 0 1"
+  },
+  {
+    "id": 7,
+    "fen": "4k2r/6r1/8/8/8/8/3R4/R3K3 w Qk - 0 1"
+  },
+  {
+    "id": 8,
+    "fen": "r1bk3r/p2pBpNp/n4n2/1p1NP2P/6P1/3P4/P1P1K3/q5b1 w - - 0 1"
+  },
+  {
+    "id": 9,
+    "fen": "1q6/2b2ppb/4p1k1/7p/2Np1p1P/3P1Q2/6PK/8 w - - 0 1"
+  },
+  {
+    "id": 10,
+    "fen": "8/p1p3pp/5ppk/6q1/5PPK/6P1/P1P3PP/8 w - - 0 1"
+  },
+  {
+    "id": 11,
+    "fen": "3Rbk1K/qqqqq1NQ/6Qq/6QQ/6Qq/2b3QQ/1B4Qq/q5R1 b - - 0 1"
+  },
+  {
+    "id": 12,
+    "fen": "r3kn1Q/p1p1bpp1/2P3bB/4R2p/8/2P1p2r/4P3/3KR3 w q - 0 1"
+  },
+  {
+    "id": 13,
+    "fen": "5k2/8/8/8/8/5q2/7Q/6QK w - - 0 1"
+  },
+  {
+    "id": 14,
+    "fen": "5k2/1Q6/8/8/7q/8/8/6QK w - - 0 1"
+  },
+  {
+    "id": 15,
+    "fen": "8/8/8/8/3K2N1/7R/4p1p1/4qkqR w - - 0 1"
+  },
+  {
+    "id": 16,
+    "fen": "rnb1kbnr/pppp1ppp/8/4p3/6Pq/5P2/PPPPP2P/RNBQKBNR w - - 0 1"
+  }
+]

--- a/render_position.py
+++ b/render_position.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Chess Position Renderer
+
+Generates chess position images by combining board and piece PNGs based on a FEN string.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image
+
+
+# Default starting position FEN
+DEFAULT_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+DEFAULT_SIZE = 80
+DEFAULT_OUTPUT = "chess_position.png"
+
+# Mapping FEN characters to piece filenames
+PIECE_MAP = {
+    'r': 'br.png',  # black rook
+    'n': 'bn.png',  # black knight
+    'b': 'bb.png',  # black bishop
+    'q': 'bq.png',  # black queen
+    'k': 'bk.png',  # black king
+    'p': 'bp.png',  # black pawn
+    'R': 'wr.png',  # white rook
+    'N': 'wn.png',  # white knight
+    'B': 'wb.png',  # white bishop
+    'Q': 'wq.png',  # white queen
+    'K': 'wk.png',  # white king
+    'P': 'wp.png',  # white pawn
+}
+
+
+def parse_fen(fen: str) -> list[list[Optional[str]]]:
+    """
+    Parse FEN string and return 8x8 board representation.
+
+    Returns a 2D list where board[rank][file] contains the FEN character
+    for the piece at that position, or None for empty squares.
+    Rank 0 = visual top (rank 8), Rank 7 = visual bottom (rank 1).
+    """
+    # Extract just the board layout part (before first space)
+    board_layout = fen.split()[0]
+
+    # Split into ranks (8 to 1, top to bottom)
+    ranks = board_layout.split('/')
+
+    if len(ranks) != 8:
+        raise ValueError(f"Invalid FEN: expected 8 ranks, got {len(ranks)}")
+
+    board: list[list[Optional[str]]] = []
+
+    for rank in ranks:
+        row: list[Optional[str]] = []
+        for char in rank:
+            if char.isdigit():
+                # Empty squares
+                row.extend([None] * int(char))
+            elif char in PIECE_MAP:
+                row.append(char)
+            else:
+                raise ValueError(f"Invalid FEN character: {char}")
+
+        if len(row) != 8:
+            raise ValueError(f"Invalid FEN: rank has {len(row)} squares instead of 8")
+
+        board.append(row)
+
+    return board
+
+
+def load_fen_by_id(position_id: int, fen_file: str = "fen.json") -> str:
+    """
+    Load a FEN string from the JSON file by ID.
+
+    Args:
+        position_id: The ID of the position to load
+        fen_file: Path to the JSON file containing positions (default: fen.json)
+
+    Returns:
+        The FEN string for the specified position
+
+    Raises:
+        FileNotFoundError: If the JSON file doesn't exist
+        ValueError: If the ID is not found in the file
+    """
+    fen_path = Path(fen_file)
+
+    if not fen_path.exists():
+        raise FileNotFoundError(f"FEN file not found: {fen_path}")
+
+    with open(fen_path, 'r') as f:
+        positions = json.load(f)
+
+    for position in positions:
+        if position.get('id') == position_id:
+            return position['fen']
+
+    raise ValueError(f"Position with ID {position_id} not found in {fen_file}")
+
+
+def render_position(
+    fen: str,
+    board_name: str,
+    pieces_name: str,
+    size: int,
+    output: str,
+    side: str = 'white'
+) -> None:
+    """
+    Render a chess position to an image file.
+
+    Args:
+        fen: FEN string representing the position
+        board_name: Name of the board style (without .png)
+        pieces_name: Name of the pieces directory
+        size: Size of each square in pixels
+        output: Output filename
+        side: Perspective to render from ('white' or 'black', default 'white')
+    """
+    # Validate paths
+    board_path = Path(f"boards/{board_name}.png")
+    pieces_dir = Path(f"pieces/{pieces_name}")
+
+    if not board_path.exists():
+        raise FileNotFoundError(f"Board not found: {board_path}")
+
+    if not pieces_dir.exists():
+        raise FileNotFoundError(f"Pieces directory not found: {pieces_dir}")
+
+    # Parse FEN
+    board = parse_fen(fen)
+
+    # Load and resize board
+    board_img = Image.open(board_path)
+    board_size = size * 8
+    board_img = board_img.resize((board_size, board_size), Image.Resampling.LANCZOS)
+
+    # Convert to RGBA to handle transparency
+    if board_img.mode != 'RGBA':
+        board_img = board_img.convert('RGBA')
+
+    # Rotate board 180° if viewing from black's perspective
+    if side == 'black':
+        board_img = board_img.rotate(180)
+
+    # Create a new image for compositing
+    final_img = board_img.copy()
+
+    # Place pieces on the board
+    for rank_idx, rank in enumerate(board):
+        for file_idx, piece_char in enumerate(rank):
+            if piece_char is not None:
+                # Get piece filename
+                piece_filename = PIECE_MAP[piece_char]
+                piece_path = pieces_dir / piece_filename
+
+                if not piece_path.exists():
+                    print(f"Warning: Piece file not found: {piece_path}", file=sys.stderr)
+                    continue
+
+                # Load and resize piece
+                piece_img = Image.open(piece_path)
+                piece_img = piece_img.resize((size, size), Image.Resampling.LANCZOS)
+
+                # Convert to RGBA
+                if piece_img.mode != 'RGBA':
+                    piece_img = piece_img.convert('RGBA')
+
+                # Calculate position on board
+                if side == 'black':
+                    # Flip coordinates for black's perspective
+                    x = (7 - file_idx) * size
+                    y = (7 - rank_idx) * size
+                else:
+                    x = file_idx * size
+                    y = rank_idx * size
+
+                # Paste piece onto board with transparency
+                final_img.paste(piece_img, (x, y), piece_img)
+
+    # Save the final image
+    final_img.save(output)
+    print(f"Chess position rendered to: {output}")
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Render chess positions from FEN notation using chess.com board and piece images.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Starting position with brown board and alpha pieces
+  %(prog)s --board brown --pieces alpha --size 80
+
+  # Custom position
+  %(prog)s --fen "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4" --board marble --pieces 3d_wood --size 100
+        """
+    )
+
+    # Create mutually exclusive group for FEN input methods
+    fen_group = parser.add_mutually_exclusive_group()
+
+    fen_group.add_argument(
+        '--fen',
+        type=str,
+        help=f'FEN string representing the chess position (default: starting position if neither --fen nor --id provided)'
+    )
+
+    fen_group.add_argument(
+        '--id',
+        type=int,
+        help='Load FEN from fen.json by position ID'
+    )
+
+    parser.add_argument(
+        '--board',
+        type=str,
+        required=True,
+        help='Board style name without .png extension (e.g., "brown", "marble")'
+    )
+
+    parser.add_argument(
+        '--pieces',
+        type=str,
+        required=True,
+        help='Pieces directory name (e.g., "alpha", "3d_wood")'
+    )
+
+    parser.add_argument(
+        '--size',
+        type=int,
+        default=DEFAULT_SIZE,
+        help=f'Size of each square in pixels (default: {DEFAULT_SIZE})'
+    )
+
+    parser.add_argument(
+        '--side',
+        type=str,
+        choices=['white', 'black'],
+        default='white',
+        help='Perspective to render from: white (bottom) or black (top). Default: white'
+    )
+
+    parser.add_argument(
+        '--output',
+        type=str,
+        default=DEFAULT_OUTPUT,
+        help=f'Output filename (default: {DEFAULT_OUTPUT})'
+    )
+
+    args = parser.parse_args()
+
+    try:
+        # Determine which FEN to use
+        if args.id is not None:
+            fen = load_fen_by_id(args.id)
+        elif args.fen is not None:
+            fen = args.fen
+        else:
+            fen = DEFAULT_FEN
+
+        render_position(
+            fen=fen,
+            board_name=args.board,
+            pieces_name=args.pieces,
+            size=args.size,
+            output=args.output,
+            side=args.side
+        )
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 httpx
+Pillow


### PR DESCRIPTION
## Summary

This PR adds a chess position renderer that generates board images from FEN notation:

- **render_position.py**: CLI tool to render chess positions by combining board and piece PNGs
- **fen.json**: Collection of 16 example chess positions for testing
- **Pillow dependency**: Added for image processing and compositing

## Features

- Support for all board styles and piece sets in the repository
- FEN notation input with validation
- Load positions from JSON by ID
- Configurable square sizes
- Render from either player's perspective (white/black)
- Custom output filenames

## Example Usage

```bash
# Render starting position
python render_position.py --board brown --pieces alpha --size 80

# Render custom position from FEN
python render_position.py --fen "r1bqkb1r/pppp1ppp/2n2n2/4p3/2B1P3/5N2/PPPP1PPP/RNBQK2R w KQkq - 4 4" --board marble --pieces 3d_wood

# Load position from fen.json by ID
python render_position.py --id 5 --board brown --pieces alpha --side black
```